### PR TITLE
[web-extension] Open Download link in new window

### DIFF
--- a/web-extension/extension/src/base/options.html
+++ b/web-extension/extension/src/base/options.html
@@ -54,7 +54,7 @@
                         <span id="install-message">Go to link below to install the application for your operating system.</span>
                     </p>
                     <p>
-                        <span><a id="install-message-link" href="https://www.arrow-dl.com/ArrowDL/category/download.html">Visit ArrowDL website</a></span>
+                        <span><a id="install-message-link" target="_blank" href="https://www.arrow-dl.com/ArrowDL/category/download.html">Visit ArrowDL website</a></span>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Now when you click on a link from the Extensions menu, the Download page does not load ([proof](https://github.com/setvisible/ArrowDL/assets/24810600/c21cec81-d486-4207-ac76-33d8ceec4188)). I suggest opening this link in new tab.